### PR TITLE
OTHER: #include <stdio.h> for fprintf

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,22 +1,23 @@
-LIBS=`pkg-config --libs xmms2-client`
-GLIB=`pkg-config --libs xmms2-client-glib` `pkg-config --libs glib-2.0`
+CFLAGS_XMMS2=`pkg-config --cflags xmms2-client`
+CFLAGS_GLIB=`pkg-config --cflags glib-2.0`
+LIBS_XMMS2=`pkg-config --libs xmms2-client`
+LIBS_GLIB=`pkg-config --libs xmms2-client-glib` `pkg-config --libs glib-2.0`
 
-all: tut1 tut2 tut3 tut4 tut5 tut6 tut7 tut8
+all: xmms2 xmms2glib
+
+xmms2: CFLAGS=$(CFLAGS_XMMS2)
+xmms2: LIBS=$(LIBS_XMMS2)
+xmms2: tut1 tut2 tut3 tut4 tut5
+
+xmms2glib: CFLAGS=$(CFLAGS_XMMS2) $(CFLAGS_GLIB)
+xmms2glib: LIBS=$(LIBS_XMMS2) $(LIBS_GLIB)
+xmms2glib: tut6 tut7 tut8
 
 %.o: %.c
-	gcc `pkg-config --cflags xmms2-client glib-2.0` -Wall -c -o $@ $< 
+	gcc $(CFLAGS) -Wall -c -o $@ $< 
 
 tut%: tut%.o
 	gcc -o $@ $< $(LIBS)
-
-tut6: tut6.o
-	gcc -o $@ $< $(LIBS) $(GLIB)
-
-tut7: tut7.o
-	gcc -o $@ $< $(LIBS) $(GLIB)
-
-tut8: tut8.o
-	gcc -o $@ $< $(LIBS) $(GLIB)
 
 clean:
 	rm -f tut? *.o

--- a/c/tut1.c
+++ b/c/tut1.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>

--- a/c/tut2.c
+++ b/c/tut2.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>

--- a/c/tut3.c
+++ b/c/tut3.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>

--- a/c/tut4.c
+++ b/c/tut4.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>

--- a/c/tut5.c
+++ b/c/tut5.c
@@ -132,7 +132,7 @@ main (int argc, char **argv)
 	 * Values that we need later
 	 */
 
-	connection = xmmsc_init ("tutorial1");
+	connection = xmmsc_init ("tutorial5");
 	if (!connection) {
 		fprintf (stderr, "OOM!\n");
 		exit (EXIT_FAILURE);

--- a/c/tut5.c
+++ b/c/tut5.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>

--- a/c/tut6.c
+++ b/c/tut6.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>

--- a/c/tut6.c
+++ b/c/tut6.c
@@ -90,7 +90,7 @@ main (int argc, char **argv)
 	 * normal. Read up on this in earlier
 	 * tutorials if you need.
 	 */
-	connection = xmmsc_init ("tutorial6");
+	connection = xmmsc_init ("tutorial7");
 	if (!connection) {
 		fprintf (stderr, "OOM!\n");
 		exit (EXIT_FAILURE);

--- a/c/tut7.c
+++ b/c/tut7.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>

--- a/c/tut7.c
+++ b/c/tut7.c
@@ -114,7 +114,7 @@ main (int argc, char **argv)
 	 * normal. Read up on this in earlier
 	 * tutorials if you need.
 	 */
-	connection = xmmsc_init ("tutorial6");
+	connection = xmmsc_init ("tutorial8");
 	if (!connection) {
 		fprintf (stderr, "OOM!\n");
 		exit (EXIT_FAILURE);

--- a/c/tut8.c
+++ b/c/tut8.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /* include xmmsclient header */
 #include <xmmsclient/xmmsclient.h>


### PR DESCRIPTION
Fails to build with: gcc (Debian 8.2.0-10) 8.2.0

gcc `pkg-config --cflags xmms2-client glib-2.0` -Wall -c -o tut1.o tut1.c 
tut1.c: In function ‘main’:
tut1.c:69:3: warning: implicit declaration of function ‘fprintf’ [-Wimplicit-function-declaration]
   fprintf (stderr, "OOM!\n");
   ^~~~~~~
tut1.c:69:3: warning: incompatible implicit declaration of built-in function ‘fprintf’
tut1.c:69:3: note: include ‘<stdio.h>’ or provide a declaration of ‘fprintf’
tut1.c:21:1:
+#include <stdio.h>
 
tut1.c:69:3:
   fprintf (stderr, "OOM!\n");
   ^~~~~~~
tut1.c:69:12: error: ‘stderr’ undeclared (first use in this function)
   fprintf (stderr, "OOM!\n");
            ^~~~~~
tut1.c:69:12: note: ‘stderr’ is defined in header ‘<stdio.h>’; did you forget to ‘#include <stdio.h>’?
tut1.c:69:12: note: each undeclared identifier is reported only once for each function it appears in
tut1.c:86:3: warning: incompatible implicit declaration of built-in function ‘fprintf’
   fprintf (stderr, "Connection failed: %s\n",
   ^~~~~~~
tut1.c:86:3: note: include ‘<stdio.h>’ or provide a declaration of ‘fprintf’
tut1.c:121:3: warning: incompatible implicit declaration of built-in function ‘fprintf’
   fprintf (stderr, "playback start returned error, %s",
   ^~~~~~~
tut1.c:121:3: note: include ‘<stdio.h>’ or provide a declaration of ‘fprintf’
make: *** [Makefile:7: tut1.o] Error 1